### PR TITLE
Debug dict

### DIFF
--- a/nodes/general/general_load_gis_data.py
+++ b/nodes/general/general_load_gis_data.py
@@ -15,10 +15,11 @@ import sverchok_gis
 from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 from sverchok_gis.utils import gis_loader
+from sverchok_gis.utils.modules.mixin_debug_dict import SvSGNDebugMixinDict
 
 gpd_read_file = gis_loader.get_loader()
 
-class SvSGNLoadGISData(SverchCustomTreeNode, bpy.types.Node):
+class SvSGNLoadGISData(SverchCustomTreeNode, bpy.types.Node, SvSGNDebugMixinDict):
     """
     Triggers: load GIS data using parameters
     Tooltip: Import GPKG data
@@ -63,6 +64,9 @@ class SvSGNLoadGISData(SverchCustomTreeNode, bpy.types.Node):
 
             gpd1 = gpd_read_file(path, **parameters)
             gi = gpd1.__geo_interface__
+
+            if self.sgn_debug_mode:
+                self.set_debug_dict_new_pair("first_run", gi)
         
         gis_data.append(gi)
         self.outputs["GIS data"].sv_set(gis_data)

--- a/utils/modules/mixin_debug_dict.py
+++ b/utils/modules/mixin_debug_dict.py
@@ -3,14 +3,13 @@ import bpy
 from sverchok.data_structure import node_id
 
 class SvSGNDebugMixinDict():
-	"""
-	the goal of this mixin is to abstract away the node_dict creation.
-	user/node creator should be able to just assume a node dict will be created
-	correctly, and reset if necessary.
-	"""
+    """
+    the goal of this mixin is to abstract away the node_dict creation.
+    user/node creator should be able to just assume a node dict will be created
+    correctly, and reset if necessary.
+    """
     sgn_debug_dict = dict()    # special kind of variable.
     sgn_debug_mode: bpy.types.BoolProperty(default=False, name="debug mode", description="debug switch for node")
-    
 
     def get_current_debug_dict(self):
         self.n_id = node_id(self)
@@ -20,7 +19,7 @@ class SvSGNDebugMixinDict():
             self.sgn_debug_dict[self.n_id] = {}
             found_dict = self.sgn_debug_dict[self.n_id]
         return found_dict
- 
+
     def clear_current_debug_dict(self):
         self.n_id = node_id(self)
         self.sgn_debug_dict[self.n_id] = {}

--- a/utils/modules/mixin_debug_dict.py
+++ b/utils/modules/mixin_debug_dict.py
@@ -9,7 +9,7 @@ class SvSGNDebugMixinDict():
     correctly, and reset if necessary.
     """
     sgn_debug_dict = dict()    # special kind of variable.
-    sgn_debug_mode: bpy.types.BoolProperty(default=False, name="debug mode", description="debug switch for node")
+    sgn_debug_mode: bpy.props.BoolProperty(default=False, name="debug mode", description="debug switch for node")
 
     def get_current_debug_dict(self):
         self.n_id = node_id(self)

--- a/utils/modules/mixin_debug_dict.py
+++ b/utils/modules/mixin_debug_dict.py
@@ -1,0 +1,29 @@
+# mixin_debug_dict.py
+import bpy
+from sverchok.data_structure import node_id
+
+class SvSGNDebugMixinDict():
+	"""
+	the goal of this mixin is to abstract away the node_dict creation.
+	user/node creator should be able to just assume a node dict will be created
+	correctly, and reset if necessary.
+	"""
+    sgn_debug_dict = dict()    # special kind of variable.
+    sgn_debug_mode: bpy.types.BoolProperty(default=False, name="debug mode", description="debug switch for node")
+    
+
+    def get_current_debug_dict(self):
+        self.n_id = node_id(self)
+        found_dict = self.sgn_debug_dict.get(self.n_id)
+        if not found_dict:
+            print("recreated new dict")
+            self.sgn_debug_dict[self.n_id] = {}
+            found_dict = self.sgn_debug_dict[self.n_id]
+        return found_dict
+ 
+    def clear_current_debug_dict(self):
+        self.n_id = node_id(self)
+        self.sgn_debug_dict[self.n_id] = {}
+
+    def set_debug_dict_new_pair(self, key_name, key_value):
+        self.get_current_debug_dict()[key_name] = key_value


### PR DESCRIPTION
essentially you can add code like this to any node (and the mixin - SvSGNDebugMixinDict to the class definition)
```python
from sverchok_gis.utils.modules.mixin_debug_dict import SvSGNDebugMixinDict

     ....

            if self.sgn_debug_mode:
                self.set_debug_dict_new_pair("first_run", gi)

```

if you set `sgn_debug_mode = True` , and trigger execution, then you will be able to open TextEditor and run
```python
import bpy

nt = bpy.data.node_groups['NodeTree']
n = nt.nodes.get("Load GIS data")
d = n.get_current_debug_dict()

print(d.get("first_run"))
```